### PR TITLE
feat: add operator project type

### DIFF
--- a/.github/scripts/check-drift.sh
+++ b/.github/scripts/check-drift.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # check-drift.sh
-# Compares consumer repo CLAUDE.md files against key template fingerprints.
+# Checks consumer repos for drift from their templates.
+#
+# - product-engineer: checks CLAUDE.md for required fingerprint strings
+# - operator: checks for required file existence via gh api
+#
 # Opens a GitHub issue in the consumer repo if drift is detected.
 #
 # Usage: ./check-drift.sh <consumers.json path> <template dir>
@@ -32,51 +36,107 @@ consumer_count=$(jq '. | length' "$CONSUMERS_FILE")
 
 for i in $(seq 0 $((consumer_count - 1))); do
   repo=$(jq -r ".[$i].repo" "$CONSUMERS_FILE")
-  claude_md_path=$(jq -r ".[$i].claude_md_path" "$CONSUMERS_FILE")
   template=$(jq -r ".[$i].template" "$CONSUMERS_FILE")
 
-  echo "Checking $repo ($claude_md_path)..."
+  echo "Checking $repo (template: $template)..."
 
-  # Fetch the consumer's CLAUDE.md
-  consumer_claude_md=$(gh api "repos/$repo/contents/$claude_md_path" --jq '.content' | base64 -d 2>/dev/null || echo "")
+  if [ "$template" = "operator" ]; then
+    # ── Operator: file-existence checks ──────────────────────────────────────
+    required_files=$(jq -r ".[$i].required_files[]" "$CONSUMERS_FILE" 2>/dev/null || echo "")
 
-  if [ -z "$consumer_claude_md" ]; then
-    echo "  ⚠ Could not fetch $claude_md_path from $repo — skipping"
-    continue
-  fi
-
-  # Check each fingerprint
-  missing=()
-  for fingerprint in "${FINGERPRINTS[@]}"; do
-    if ! echo "$consumer_claude_md" | grep -qF "$fingerprint"; then
-      missing+=("$fingerprint")
-    fi
-  done
-
-  if [ ${#missing[@]} -eq 0 ]; then
-    echo "  ✓ No drift detected"
-  else
-    echo "  ⚠ Drift detected — missing fingerprints: ${missing[*]}"
-
-    # Check if a drift issue already exists (avoid duplicates)
-    existing_issue=$(gh issue list --repo "$repo" --label "claude-template-drift" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
-
-    if [ -n "$existing_issue" ]; then
-      echo "  → Issue #$existing_issue already open, skipping"
+    if [ -z "$required_files" ]; then
+      echo "  ⚠ No required_files defined for operator $repo — skipping"
       continue
     fi
 
-    # Open an issue in the consumer repo
-    missing_list=""
-    for item in "${missing[@]}"; do
-      missing_list="${missing_list}- \`${item}\`\n"
+    missing_files=()
+    while IFS= read -r f; do
+      if ! gh api "repos/$repo/contents/$f" >/dev/null 2>&1; then
+        missing_files+=("$f")
+      fi
+    done <<< "$required_files"
+
+    if [ ${#missing_files[@]} -eq 0 ]; then
+      echo "  ✓ All required files present"
+    else
+      echo "  ⚠ Drift detected — missing files: ${missing_files[*]}"
+
+      # Check if a drift issue already exists (avoid duplicates)
+      existing_issue=$(gh issue list --repo "$repo" --label "claude-template-drift" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+      if [ -n "$existing_issue" ]; then
+        echo "  → Issue #$existing_issue already open, skipping"
+        continue
+      fi
+
+      missing_list=$(printf '- `%s`\n' "${missing_files[@]}")
+      gh issue create \
+        --repo "$repo" \
+        --title "⚠️ Operator scaffolding drift detected" \
+        --label "claude-template-drift" \
+        --body "## Operator Template Drift Detected
+
+This repo uses the \`operator\` template from [bh679/claude-templates](https://github.com/bh679/claude-templates) but is missing required files.
+
+### Missing Files
+
+$missing_list
+
+### What to Do
+
+1. Review the operator template: [\`templates/operator/\`](https://github.com/bh679/claude-templates/tree/main/templates/operator)
+2. Review the operator standard: [\`standards/operator.md\`](https://github.com/bh679/claude-templates/blob/main/standards/operator.md)
+3. Add the missing files to this repo
+4. Close this issue once resolved
+
+*Opened automatically by the claude-templates drift detection workflow.*"
+
+      echo "  → Opened drift issue in $repo"
+      ISSUES_OPENED=$((ISSUES_OPENED + 1))
+    fi
+
+  else
+    # ── Product-engineer (default): CLAUDE.md fingerprint checks ─────────────
+    claude_md_path=$(jq -r ".[$i].claude_md_path" "$CONSUMERS_FILE")
+
+    echo "  Checking $claude_md_path for fingerprints..."
+
+    # Fetch the consumer's CLAUDE.md
+    consumer_claude_md=$(gh api "repos/$repo/contents/$claude_md_path" --jq '.content' | base64 -d 2>/dev/null || echo "")
+
+    if [ -z "$consumer_claude_md" ]; then
+      echo "  ⚠ Could not fetch $claude_md_path from $repo — skipping"
+      continue
+    fi
+
+    # Check each fingerprint
+    missing=()
+    for fingerprint in "${FINGERPRINTS[@]}"; do
+      if ! echo "$consumer_claude_md" | grep -qF "$fingerprint"; then
+        missing+=("$fingerprint")
+      fi
     done
-    missing_list=$(printf "%b" "$missing_list")
-    gh issue create \
-      --repo "$repo" \
-      --title "⚠️ CLAUDE.md drift detected — templates updated" \
-      --label "claude-template-drift" \
-      --body "## Claude Templates Drift Detected
+
+    if [ ${#missing[@]} -eq 0 ]; then
+      echo "  ✓ No drift detected"
+    else
+      echo "  ⚠ Drift detected — missing fingerprints: ${missing[*]}"
+
+      # Check if a drift issue already exists (avoid duplicates)
+      existing_issue=$(gh issue list --repo "$repo" --label "claude-template-drift" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+      if [ -n "$existing_issue" ]; then
+        echo "  → Issue #$existing_issue already open, skipping"
+        continue
+      fi
+
+      # Open an issue in the consumer repo
+      missing_list=$(printf '- `%s`\n' "${missing[@]}")
+      gh issue create \
+        --repo "$repo" \
+        --title "⚠️ CLAUDE.md drift detected — templates updated" \
+        --label "claude-template-drift" \
+        --body "## Claude Templates Drift Detected
 
 The \`$claude_md_path\` in this repo appears to have drifted from the canonical \`$template\` template in [bh679/claude-templates](https://github.com/bh679/claude-templates).
 
@@ -93,8 +153,9 @@ $missing_list
 
 *Opened automatically by the claude-templates drift detection workflow.*"
 
-    echo "  → Opened drift issue in $repo"
-    ISSUES_OPENED=$((ISSUES_OPENED + 1))
+      echo "  → Opened drift issue in $repo"
+      ISSUES_OPENED=$((ISSUES_OPENED + 1))
+    fi
   fi
 done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ and installable skills used across all of Brennan's Claude-powered projects.
 | Directory | What it is | How it's consumed |
 |---|---|---|
 | `standards/` | Living policy docs — source of truth | Referenced by pointer comments in consumer CLAUDE.md files |
-| `templates/` | Parameterised starting points | Copied into new projects once, tokens filled in |
+| `templates/product-engineer/` | Product engineer starting point (human-initiated, 3-gate workflow) | Copied into new projects once, tokens filled in |
+| `templates/operator/` | Operator starting point (scheduled autonomous agent) | Copied into new operator projects once, tokens filled in |
 | `skills/` | Installable Claude skills (SKILL.md format) | Symlinked into `~/.claude/skills/<name>/` |
 
 ---

--- a/consumers.json
+++ b/consumers.json
@@ -10,5 +10,23 @@
     "template": "product-engineer",
     "claude_md_path": "CLAUDE.md",
     "description": "Claude Management Dashboard (formerly AutoClaude)"
+  },
+  {
+    "repo": "bh679/house-sitting-agent",
+    "template": "product-engineer",
+    "claude_md_path": "CLAUDE.md",
+    "description": "Autonomous house-sitting listing monitor and applicant"
+  },
+  {
+    "repo": "bh679/weekly-blog",
+    "template": "operator",
+    "description": "Weekly development blog writer",
+    "required_files": [
+      ".github/workflows/weekly-blog.yml",
+      ".github/scripts/fetch-all-data.sh",
+      "blog-post-guidelines.md",
+      "blog-index-template.md",
+      "state.json"
+    ]
   }
 ]

--- a/standards/operator.md
+++ b/standards/operator.md
@@ -1,0 +1,140 @@
+# Operator Standard
+
+An **Operator** is a Claude agent triggered on a schedule by GitHub Actions. It runs autonomously, gathering data and producing output (commits, issues, API calls) without a human in the loop. If something genuinely requires human attention, the Operator opens a GitHub issue and stops — it never blocks waiting for interactive input.
+
+---
+
+## Required Scaffolding Files
+
+Every Operator project must contain:
+
+| File | Purpose |
+|---|---|
+| `CLAUDE.md` | Agent instructions (role, data sources, output, tools, turn limit) |
+| `.github/workflows/<agent-name>.yml` | Cron-triggered GitHub Actions workflow |
+| `.github/scripts/fetch-data.sh` | Shell script that gathers input data before Claude runs |
+| `guidelines.md` | Output quality rules (tone, format, what to include/exclude) |
+| `state.json` | Cross-run memory (last run timestamp, snapshots for deduplication) |
+
+---
+
+## Scheduling Conventions
+
+- Use a `cron` trigger in the workflow so runs happen on a predictable schedule.
+- Always include `workflow_dispatch` alongside the cron trigger to allow manual runs.
+- Store the schedule in a single place (the workflow file). The CLAUDE.md may reference it in human-readable form (`{{SCHEDULE}}`) for context.
+
+```yaml
+on:
+  schedule:
+    - cron: '0 10 * * 1'   # Every Monday at 10:00 UTC
+  workflow_dispatch:
+```
+
+---
+
+## State Management Pattern
+
+The Operator uses `state.json` as its persistent memory across runs.
+
+**At the start of a run:** Read `state.json` to understand what was processed last time (deduplication, comparison baseline).
+
+**At the end of a run:** Update `state.json` with the new snapshot and commit it alongside any output. This ensures the next run starts from a clean baseline.
+
+Minimum shape:
+```json
+{
+  "last_run": "2025-01-27T10:00:00Z",
+  "snapshot": {}
+}
+```
+
+The `snapshot` field is agent-specific — use it for whatever the agent needs to deduplicate or compare (e.g. last-seen event IDs, post count, last-processed timestamp per source).
+
+**Never let the agent skip the state commit.** If the state isn't committed, the next run will reprocess everything from scratch.
+
+---
+
+## Guidelines Doc Pattern
+
+`guidelines.md` is a human-authored doc that the Operator reads at the start of each run before producing any output. It governs quality, not behaviour.
+
+Use it for:
+- Tone and voice (e.g. "write in first person, present tense")
+- Format rules (e.g. "use H2 headings, bullet lists for steps")
+- Length constraints (e.g. "aim for 400–600 words")
+- What to include or exclude (e.g. "skip internal tooling changes")
+- Output naming conventions (e.g. `YYYY-MM-DD.md`)
+
+Guidelines are not instructions to Claude about *what to do* — those live in `CLAUDE.md`. Guidelines are instructions about *how to do it well*.
+
+---
+
+## Allowed Tools Convention
+
+Operators use a **narrow tool list**. The principle: an Operator gathers data, thinks, and commits output. It does not edit existing source files.
+
+**Allowed:**
+- `Read` — read files in the repo (CLAUDE.md, guidelines.md, state.json, data files)
+- `Bash` — limited to `git` and `gh` commands for committing/pushing output and opening issues
+- `WebFetch` — read external URLs if needed for data gathering
+
+**Not allowed:**
+- `Edit` / `Write` — Operators write output via `git` commit, not by calling file-write tools
+- `WebSearch` — use targeted `WebFetch` with known URLs instead
+- Any destructive shell commands (`rm -rf`, `git reset --hard`, etc.)
+
+Encode these restrictions in the workflow's `allowed_tools` parameter and in the agent's `CLAUDE.md`.
+
+---
+
+## Turn Limit Convention
+
+Set a turn limit of **30 turns** for most Operators. This prevents runaway costs and enforces a focused, single-purpose run. If the task requires more turns, it likely needs to be split into multiple Operators or a more efficient data-gathering approach.
+
+Set the turn limit in the workflow's Claude Code action parameters.
+
+---
+
+## Commit and Push Procedure
+
+Operators commit and push directly to the default branch — there is no PR, no Gate workflow, no review step.
+
+**Commit message format:** `<type>: <short description>` (same convention as the rest of the repo)
+
+Common types for operators:
+- `feat` — new output created (e.g. a new blog post)
+- `chore` — state update with no meaningful new output
+- `fix` — correction to previous output
+
+**After every run that produces output:**
+```bash
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add -A
+git commit -m "feat: <description of this run's output>"
+git push
+```
+
+If nothing meaningful happened (skip guard triggered), do not commit. An empty commit is noise.
+
+---
+
+## Skip Guard
+
+Every Operator must have a skip condition: if there is nothing to do, it should exit cleanly without creating empty output or committing noise.
+
+Document the skip condition explicitly in `CLAUDE.md`. Example:
+
+> If there are no new events, no pending items, and no changes since last run, write nothing and exit. Do not commit.
+
+---
+
+## Human Escalation
+
+If the Operator encounters something it cannot handle autonomously (unexpected data shape, failed API, decision requiring judgement), it should:
+
+1. Open a GitHub issue with a clear title and description of the problem
+2. Stop the run (do not commit partial output)
+
+It should **not** attempt to interact with a user via chat or block the workflow waiting for input.

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,7 +2,9 @@
 
 ## Token Reference
 
-When copying templates, replace these tokens with project-specific values:
+### Product Engineer Tokens
+
+When copying `templates/product-engineer/`, replace these tokens:
 
 | Token | Example | Description |
 |---|---|---|
@@ -15,9 +17,40 @@ When copying templates, replace these tokens with project-specific values:
 | `{{GITHUB_USER}}` | `bh679` | GitHub username |
 | `{{WIKI_URL}}` | `github.com/bh679/chess-client/wiki` | Wiki URL for the main client/frontend repo |
 
+### Operator Tokens
+
+When copying `templates/operator/`, replace these tokens:
+
+| Token | Example | Description |
+|---|---|---|
+| `{{AGENT_NAME}}` | `Weekly Blog Writer` | Human-readable name for the operator agent |
+| `{{SCHEDULE}}` | `0 10 * * 1` | Cron expression for when the operator runs |
+| `{{TRIGGER_DESCRIPTION}}` | `Every Monday at 10:00 UTC` | Human-readable description of the schedule |
+| `{{DATA_SOURCES}}` | `GitHub events from bh679/* repos, pending-context.json` | What data the fetch script gathers |
+| `{{OUTPUT_DESCRIPTION}}` | `A weekly markdown blog post saved to posts/YYYY-MM-DD.md` | What the operator produces each run |
+
 ---
 
 ## Bootstrapping Checklist
+
+### Operator Project
+
+- [ ] Copy `templates/operator/CLAUDE.md` → `<repo>/CLAUDE.md`
+  - Replace all `{{TOKENS}}`
+  - Fill in the skip guard condition
+- [ ] Copy `templates/operator/.github/workflows/operator.yml` → `<repo>/.github/workflows/<agent-slug>.yml`
+  - Replace `{{SCHEDULE}}` with your cron expression
+  - Replace `{{AGENT_NAME}}` and `{{TRIGGER_DESCRIPTION}}`
+- [ ] Copy `templates/operator/.github/scripts/fetch-data.sh` → `<repo>/.github/scripts/fetch-data.sh`
+  - Implement the data fetching logic (replace the TODO block)
+- [ ] Copy `templates/operator/guidelines.md` → `<repo>/guidelines.md`
+  - Fill in all sections (tone, format, length, include/exclude rules)
+- [ ] Copy `templates/operator/state.json` → `<repo>/state.json`
+- [ ] Add the repo to `consumers.json` in claude-templates with `"template": "operator"` and `"required_files"`
+
+---
+
+### Product Engineer Project
 
 ### 1. Project-level setup (orchestrator repo)
 
@@ -60,6 +93,22 @@ When copying templates, replace these tokens with project-specific values:
 ---
 
 ## File Structure After Bootstrapping
+
+### Operator
+
+```
+<operator-repo>/
+├── CLAUDE.md                     (filled-in operator template)
+├── guidelines.md                 (output quality rules)
+├── state.json                    (cross-run memory)
+└── .github/
+    ├── workflows/
+    │   └── <agent-slug>.yml      (cron-triggered workflow)
+    └── scripts/
+        └── fetch-data.sh         (data gathering script)
+```
+
+### Product Engineer
 
 ```
 <project>/                        (orchestrator repo)

--- a/templates/operator/.github/scripts/fetch-data.sh
+++ b/templates/operator/.github/scripts/fetch-data.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# fetch-data.sh
+# Gathers input data for {{AGENT_NAME}} before Claude runs.
+# Called by the GitHub Actions workflow; runs with GITHUB_TOKEN in environment.
+#
+# Usage: bash .github/scripts/fetch-data.sh
+# Requires: gh CLI (authenticated via GITHUB_TOKEN), jq
+#
+# Output: write data files to the working directory so Claude can read them.
+# Example: gh api /repos/... > /tmp/data.json
+
+set -e
+
+echo "Fetching data for {{AGENT_NAME}}..."
+
+# TODO: replace with real data fetching
+# Example:
+#   gh api /repos/bh679/my-repo/events > /tmp/github-events.json
+#   echo "Fetched $(jq length /tmp/github-events.json) events"
+
+echo "Done."

--- a/templates/operator/.github/workflows/operator.yml
+++ b/templates/operator/.github/workflows/operator.yml
@@ -1,0 +1,34 @@
+name: {{AGENT_NAME}}
+
+on:
+  schedule:
+    - cron: '{{SCHEDULE}}'   # {{TRIGGER_DESCRIPTION}}
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash .github/scripts/fetch-data.sh
+
+      - name: Run {{AGENT_NAME}}
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          max_turns: 30
+          allowed_tools: "Read,Bash(git:gh)"
+          prompt: |
+            Read CLAUDE.md and follow it completely.

--- a/templates/operator/CLAUDE.md
+++ b/templates/operator/CLAUDE.md
@@ -1,0 +1,97 @@
+# {{AGENT_NAME}}
+
+<!-- Operator template — github.com/bh679/claude-templates -->
+<!-- Standard: standards/operator.md -->
+
+You are **{{AGENT_NAME}}**, an autonomous Claude operator. You run on a schedule ({{SCHEDULE}}) triggered by GitHub Actions. Your job: {{TRIGGER_DESCRIPTION}}.
+
+You operate without human interaction. If something genuinely requires human attention, open a GitHub issue describing the problem and stop — never block waiting for input.
+
+---
+
+## Data Sources
+
+Before you run, the workflow has executed `.github/scripts/fetch-data.sh` and saved its output. Your data sources are:
+
+{{DATA_SOURCES}}
+
+Read `guidelines.md` before producing any output. It governs tone, format, and quality.
+
+---
+
+## Your Output
+
+{{OUTPUT_DESCRIPTION}}
+
+After producing output, update `state.json` with the current run timestamp and any snapshot data needed for deduplication next run.
+
+Commit everything in one commit and push:
+
+```bash
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add -A
+git commit -m "feat: <short description of this run's output>"
+git push
+```
+
+---
+
+## State Management
+
+At the start of each run, read `state.json` to understand what was processed last time. Use it to avoid duplicating output across runs.
+
+At the end of each run, update `state.json`:
+```json
+{
+  "last_run": "<ISO timestamp>",
+  "snapshot": { }
+}
+```
+
+Always commit the updated `state.json` alongside your output. If you skip writing output (skip guard triggered), do not commit.
+
+---
+
+## Skip Guard
+
+If there is nothing meaningful to do — no new data, no changes since last run, nothing to report — exit cleanly without writing output or committing. An empty commit is noise.
+
+Document your skip condition here:
+> <!-- TODO: define the condition under which this operator should do nothing -->
+
+---
+
+## Allowed Tools
+
+- `Read` — read files in this repo
+- `Bash` — `git` and `gh` commands only (commit, push, open issues)
+- `WebFetch` — fetch specific URLs if needed
+
+Do not use `Edit`, `Write`, `WebSearch`, or any destructive shell commands.
+
+---
+
+## Turn Limit
+
+Complete your work in **30 turns or fewer**. If you need more, the task scope is too large — break it up or improve data pre-processing in the fetch script.
+
+---
+
+## Commit Message Format
+
+`<type>: <short description>`
+
+Types: `feat` (new output), `chore` (state update only), `fix` (correction to prior output)
+
+Examples:
+- `feat: weekly update 2025-01-27`
+- `chore: update state after empty run skipped`
+
+---
+
+## Human Escalation
+
+If you encounter an unrecoverable error or a decision requiring human judgement:
+1. Open a GitHub issue: `gh issue create --title "..." --body "..."`
+2. Stop. Do not commit partial output.

--- a/templates/operator/guidelines.md
+++ b/templates/operator/guidelines.md
@@ -1,0 +1,34 @@
+# {{AGENT_NAME}} Output Guidelines
+
+<!-- This file is read by the agent before producing output. -->
+<!-- It governs quality, tone, and format — not what the agent does. -->
+<!-- Fill in each section with your project-specific rules. -->
+
+## Tone and Voice
+
+<!-- e.g. "Write in first person, present tense." -->
+<!-- e.g. "Friendly but professional; avoid jargon." -->
+
+## Format
+
+<!-- e.g. "Use H2 headings for sections, bullet lists for steps." -->
+<!-- e.g. "File naming: YYYY-MM-DD.md" -->
+
+## Length
+
+<!-- e.g. "Aim for 400–600 words per post." -->
+<!-- e.g. "Keep entries concise; one paragraph per item." -->
+
+## What to Include
+
+<!-- e.g. "All merged PRs from the past week." -->
+<!-- e.g. "Any items flagged as 'highlight' in the source data." -->
+
+## What to Exclude
+
+<!-- e.g. "Internal tooling changes (deps, CI tweaks)." -->
+<!-- e.g. "Anything marked draft or WIP." -->
+
+## Output Naming
+
+<!-- e.g. "Save posts as posts/YYYY-MM-DD.md" -->

--- a/templates/operator/state.json
+++ b/templates/operator/state.json
@@ -1,0 +1,1 @@
+{"last_run": null, "snapshot": {}}


### PR DESCRIPTION
## Summary

- Adds `standards/operator.md` — canonical standard for scheduled autonomous Claude agents
- Adds `templates/operator/` — copy-once template (CLAUDE.md, workflow, fetch-data.sh, guidelines.md, state.json)
- Extends `check-drift.sh` to handle operator type via file-existence checks (product-engineer fingerprint logic untouched)
- Adds `bh679/weekly-blog` (operator) and `bh679/house-sitting-agent` (product-engineer) to `consumers.json`
- Updates `templates/README.md` with operator token table and bootstrapping checklist
- Updates root `CLAUDE.md` table to list both template types

## Test plan

- [ ] `jq . consumers.json` returns valid JSON with 3 entries
- [ ] `bash -n .github/scripts/check-drift.sh` passes syntax check
- [ ] All `templates/operator/` files present including nested `.github/` dirs
- [ ] `standards/operator.md` covers all 8 required topics (scaffolding, scheduling, state, guidelines, tools, turns, commit, escalation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)