### PR TITLE
feat: add pre-commit version check hook and install script

### DIFF
--- a/standards/hooks/README.md
+++ b/standards/hooks/README.md
@@ -1,0 +1,85 @@
+# Git Hooks
+
+> Reusable git hooks that enforce standards across all Claude-powered projects.
+> See [`versioning.md`](../versioning.md) for the V.MM.PPPP format specification.
+
+---
+
+## Available Hooks
+
+### `pre-commit-version-check.sh`
+
+Runs before every commit to enforce two rules:
+
+1. **Version was bumped** — `package.json` version must differ from the previous commit (PPPP bump at minimum)
+2. **Format is valid** — version must match `V.MM.PPPP` (`1.02.0015`, not `v1.2.15`)
+
+| Segment | Rules |
+|---|---|
+| `V` | Integer (e.g. `0`, `1`, `2`) |
+| `MM` | 2-digit, zero-padded (`01`, `02`, ..., `99`) |
+| `PPPP` | 4-digit, zero-padded (`0000`, `0001`, ..., `9999`) |
+
+#### Error examples
+
+```
+ERROR: Version was not bumped.
+  Previous: 1.02.0015
+  Current:  1.02.0015
+
+Every commit must bump the version (PPPP at minimum).
+Example: 1.02.0015 -> 1.02.0016
+```
+
+```
+ERROR: Invalid version format in package.json.
+  Found:    "1.2.15"
+  Expected: V.MM.PPPP (e.g. 1.02.0015)
+```
+
+---
+
+## Installation
+
+### Quick install
+
+From your **project root** (the repo you want to add the hook to):
+
+```bash
+~/Projects/Claude\ Templates/standards/hooks/install-hooks.sh
+```
+
+This copies the hook into `.git/hooks/pre-commit`. If a pre-commit hook already exists, it is backed up to `.git/hooks/pre-commit.bak`.
+
+### Manual install
+
+```bash
+cp ~/Projects/Claude\ Templates/standards/hooks/pre-commit-version-check.sh \
+   .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+### Worktree support
+
+The install script detects worktrees automatically — it installs to the correct `.git/hooks/` directory regardless of whether you're in a worktree or the main repo.
+
+---
+
+## Skipping the hook
+
+If you need to bypass the version check for a specific commit (e.g. docs-only changes):
+
+```bash
+git commit --no-verify -m "docs: update README"
+```
+
+Use sparingly. The standard expects every commit to bump the version.
+
+---
+
+## Adding new hooks
+
+1. Create the hook script in this directory: `standards/hooks/<hook-name>.sh`
+2. Make it executable: `chmod +x <hook-name>.sh`
+3. Update `install-hooks.sh` to include the new hook
+4. Document it in this README

--- a/standards/hooks/install-hooks.sh
+++ b/standards/hooks/install-hooks.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# install-hooks.sh
+#
+# Installs pre-commit hooks into a project's .git/hooks/ directory.
+# Run this from the target project's root, passing the path to the
+# claude-templates standards/hooks directory.
+#
+# Usage:
+#   /path/to/claude-templates/standards/hooks/install-hooks.sh
+#
+# Or from a project root:
+#   ~/Projects/Claude\ Templates/standards/hooks/install-hooks.sh
+
+set -euo pipefail
+
+# --- Helpers ---
+red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
+green() { printf '\033[1;32m%s\033[0m\n' "$*"; }
+dim()   { printf '\033[2m%s\033[0m\n' "$*"; }
+
+# --- Resolve paths ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_SOURCE="${SCRIPT_DIR}/pre-commit-version-check.sh"
+
+# Find the .git/hooks directory — supports worktrees
+GIT_DIR="$(git rev-parse --git-dir 2>/dev/null)" || {
+    red "ERROR: Not inside a git repository."
+    red "Run this script from your project's root directory."
+    exit 1
+}
+
+HOOKS_DIR="${GIT_DIR}/hooks"
+HOOK_TARGET="${HOOKS_DIR}/pre-commit"
+
+# --- Validate source ---
+if [ ! -f "${HOOK_SOURCE}" ]; then
+    red "ERROR: Hook source not found at ${HOOK_SOURCE}"
+    exit 1
+fi
+
+# --- Check for existing hook ---
+if [ -f "${HOOK_TARGET}" ]; then
+    dim "Existing pre-commit hook found at ${HOOK_TARGET}"
+    dim "Contents will be backed up to ${HOOK_TARGET}.bak"
+    cp "${HOOK_TARGET}" "${HOOK_TARGET}.bak"
+fi
+
+# --- Install ---
+mkdir -p "${HOOKS_DIR}"
+cp "${HOOK_SOURCE}" "${HOOK_TARGET}"
+chmod +x "${HOOK_TARGET}"
+
+green "Installed pre-commit hook to ${HOOK_TARGET}"
+dim "The hook enforces V.MM.PPPP version bumping on every commit."
+dim "See standards/versioning.md for format details."

--- a/standards/hooks/pre-commit-version-check.sh
+++ b/standards/hooks/pre-commit-version-check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# pre-commit-version-check.sh
+#
+# Pre-commit hook that enforces the V.MM.PPPP versioning standard.
+# See standards/versioning.md for format details.
+#
+# Checks:
+#   1. package.json version was bumped compared to the previous commit
+#   2. Version matches V.MM.PPPP format (V integer, MM 2-digit zero-padded, PPPP 4-digit zero-padded)
+#
+# Usage: Copy or symlink into .git/hooks/pre-commit
+#        or use install-hooks.sh to install automatically.
+
+set -euo pipefail
+
+# --- Configuration ---
+PACKAGE_JSON="package.json"
+# Regex: integer DOT 2-digit-zero-padded DOT 4-digit-zero-padded
+VERSION_REGEX='^[0-9]+\.[0-9]{2}\.[0-9]{4}$'
+
+# --- Helpers ---
+red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
+green() { printf '\033[1;32m%s\033[0m\n' "$*"; }
+dim()   { printf '\033[2m%s\033[0m\n' "$*"; }
+
+# --- Pre-flight ---
+# Skip if package.json is not tracked or not being committed
+if ! git diff --cached --name-only | grep -q "^${PACKAGE_JSON}$"; then
+    # package.json isn't staged — check if it even exists in HEAD
+    if git show HEAD:"${PACKAGE_JSON}" > /dev/null 2>&1; then
+        red "ERROR: package.json was not modified in this commit."
+        red "Every commit must bump the version (PPPP at minimum)."
+        dim "Format: V.MM.PPPP — see standards/versioning.md"
+        dim ""
+        dim "  Current version: $(git show HEAD:${PACKAGE_JSON} | grep '"version"' | head -1 | sed 's/.*: *"//;s/".*//')"
+        dim ""
+        dim "Bump the patch number and stage package.json, then retry."
+        exit 1
+    else
+        # No package.json in the repo yet — first commit, skip check
+        exit 0
+    fi
+fi
+
+# --- Extract versions ---
+# Current (staged) version
+CURRENT_VERSION=$(git show :"${PACKAGE_JSON}" | grep '"version"' | head -1 | sed 's/.*: *"//;s/".*//')
+
+# Previous (HEAD) version — empty string if this is the first commit
+if git rev-parse HEAD > /dev/null 2>&1; then
+    PREVIOUS_VERSION=$(git show HEAD:"${PACKAGE_JSON}" 2>/dev/null | grep '"version"' | head -1 | sed 's/.*: *"//;s/".*//' || echo "")
+else
+    PREVIOUS_VERSION=""
+fi
+
+# --- Validate format ---
+if ! echo "${CURRENT_VERSION}" | grep -qE "${VERSION_REGEX}"; then
+    red "ERROR: Invalid version format in package.json."
+    red "  Found:    \"${CURRENT_VERSION}\""
+    red "  Expected: V.MM.PPPP (e.g. 1.02.0015)"
+    dim ""
+    dim "Rules:"
+    dim "  V    = integer (no leading zeros unless V=0)"
+    dim "  MM   = 2-digit zero-padded (01, 02, ..., 99)"
+    dim "  PPPP = 4-digit zero-padded (0000, 0001, ..., 9999)"
+    dim ""
+    dim "See standards/versioning.md for details."
+    exit 1
+fi
+
+# --- Compare versions ---
+if [ -n "${PREVIOUS_VERSION}" ] && [ "${CURRENT_VERSION}" = "${PREVIOUS_VERSION}" ]; then
+    red "ERROR: Version was not bumped."
+    red "  Previous: ${PREVIOUS_VERSION}"
+    red "  Current:  ${CURRENT_VERSION}"
+    dim ""
+    dim "Every commit must bump the version (PPPP at minimum)."
+    dim "Format: V.MM.PPPP — see standards/versioning.md"
+    dim ""
+    dim "Example: ${PREVIOUS_VERSION} -> $(echo "${PREVIOUS_VERSION}" | awk -F. '{printf "%s.%s.%04d", $1, $2, $3+1}')"
+    exit 1
+fi
+
+green "Version check passed: ${PREVIOUS_VERSION:-"(initial)"} -> ${CURRENT_VERSION}"
+exit 0


### PR DESCRIPTION
## Summary
- Add reusable pre-commit hook (`standards/hooks/pre-commit-version-check.sh`) that enforces V.MM.PPPP version bumping on every commit
- Add install script (`standards/hooks/install-hooks.sh`) that copies the hook into any project's `.git/hooks/` with worktree support and backup
- Add documentation (`standards/hooks/README.md`) with usage instructions and error examples

## Test plan
- [ ] Run `install-hooks.sh` from a consumer project root and verify hook is installed
- [ ] Commit without bumping version — verify hook blocks with clear error
- [ ] Commit with invalid version format (e.g. `1.2.15`) — verify format error
- [ ] Commit with valid version bump — verify hook passes
- [ ] Test in a worktree — verify correct `.git/hooks/` path is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)