### PR TITLE
fix: remove self-referential INCLUDE tokens from base templates

### DIFF
--- a/.github/scripts/skills-versions.json
+++ b/.github/scripts/skills-versions.json
@@ -3,7 +3,7 @@
   "ecc-git-workflow": "1.0.0",
   "ecc-performance": "1.0.0",
   "ecc-security": "1.0.0",
-  "new-project": "1.1.1",
+  "new-project": "1.2.0",
   "search-first": "1.0.0",
   "strategic-compact": "1.0.0",
   "trigger-blog": "1.0.0",

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-project
-version: 1.1.1
+version: 1.2.0
 description: >
   Bootstrap a new project using claude-templates standards and templates.
   Use when the user says "set up a new project", "create a new repo",
@@ -94,9 +94,20 @@ After copying any template file, resolve tokens **before** replacing value token
 For each `{{INCLUDE:<path>}}` found in the copied file:
 1. Read the referenced file from `~/Projects/Claude Templates/templates/<path>`
 2. Replace the entire `{{INCLUDE:<path>}}` line with the file contents
-3. Repeat until no `{{INCLUDE:...}}` tokens remain (includes can be nested)
+3. Repeat until no live `{{INCLUDE:...}}` tokens remain (includes can be nested)
 
 Example: `{{INCLUDE:engineering/base.md}}` reads `~/Projects/Claude Templates/templates/engineering/base.md` and inlines it.
+
+**A live token is a token alone on its own line.** Skip anything else:
+- Tokens inside an HTML comment (`<!-- ... -->`) are provenance markers recording where a
+  shared file gets inlined. Leave them exactly as they are.
+- Tokens inside a code span or fenced code block are documentation examples, not directives.
+
+**Stop if a path repeats.** Track the set of paths already inlined during this file's
+resolution. If a path comes up a second time, the include is self-referential or cyclic —
+leave the token in place and report it to the user rather than looping. Correctly authored
+shared files never name themselves, so a repeat means the template has a bug worth fixing
+at the source.
 
 ### Resolution order
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -10,6 +10,19 @@ Inline shared content from another file. Path is relative to the `templates/` di
 
 **Example:** `{{INCLUDE:engineering/base.md}}` inlines `templates/engineering/base.md`.
 
+**Authoring rule — never write a self-referential include token.** A shared file that is
+itself inlined (`engineering/base.md`, `operator-base.md`, `project-overview.md`) must not
+contain a literal include token naming itself, not even inside an HTML comment. Resolution
+is recursive, so the resolver would re-emit the token every pass and loop forever. Name the
+path in prose instead:
+
+```markdown
+<!-- Included at copy time via an INCLUDE directive pointing at engineering/base.md -->
+```
+
+This document is reference material and is never copied into a project, so the token
+examples above are illustrative rather than live.
+
 ### 2. Value Tokens — `{{TOKEN_NAME}}`
 
 Replaced with project-specific values collected during setup.

--- a/templates/engineering/base.md
+++ b/templates/engineering/base.md
@@ -1,5 +1,7 @@
 <!-- Engineering base — github.com/bh679/claude-templates/templates/engineering/base.md -->
-<!-- Included at copy time via {{INCLUDE:engineering/base.md}} -->
+<!-- Included at copy time via an INCLUDE directive pointing at engineering/base.md.
+     Never write that token literally in this file — it is inlined into itself, so a
+     literal token would make recursive include resolution loop forever. -->
 
 ## Standards
 

--- a/templates/operator-base.md
+++ b/templates/operator-base.md
@@ -1,5 +1,7 @@
 <!-- Operator base — github.com/bh679/claude-templates/templates/operator-base.md -->
-<!-- Included at copy time via {{INCLUDE:operator-base.md}} -->
+<!-- Included at copy time via an INCLUDE directive pointing at operator-base.md.
+     Never write that token literally in this file — it is inlined into itself, so a
+     literal token would make recursive include resolution loop forever. -->
 
 ## State Management
 

--- a/wiki/Token-System.md
+++ b/wiki/Token-System.md
@@ -31,6 +31,8 @@ Replaced with project-specific values collected during setup. Examples: `{{PROJE
 ## Technical Notes
 
 - Available standards: workflow, git, versioning, wiki-writing, operator, http-diagnostics, unit-testing
+- A shared file that is itself inlined must never contain an include token naming itself — not even inside an HTML comment. Resolution is recursive, so the token would be re-emitted every pass and loop forever. Provenance comments name the path in prose instead.
+- Only a token alone on its own line is live. Tokens inside HTML comments or code spans are documentation and are left as-is.
 - Token reference tables for each template type are in `templates/README.md`
 - The `/new-project` skill automates the full resolution process
 


### PR DESCRIPTION
## Problem

`templates/engineering/base.md` and `templates/operator-base.md` each carried a provenance
comment on line 2 containing a **literal include token naming the file itself**:

```html
<!-- Included at copy time via {{INCLUDE:engineering/base.md}} -->
```

It was intended as a human-readable label. But `/new-project` Step 2b instructs the agent to
"repeat until no `{{INCLUDE:...}}` tokens remain" — so a resolver following that literally
inlines `base.md`, sees a fresh token pointing back at `base.md`, inlines it again, and never
terminates.

**Impact was wider than the two base files.** Simulating the naive resolver over every
template entry point, 6 of 7 failed to terminate — every template that inherits these bases:

| Entry point | Before | After |
|---|---|---|
| `engineering/product/CLAUDE.md` | ∞ | 3 passes |
| `engineering/backend/CLAUDE.md` | ∞ | 3 passes |
| `operator/CLAUDE.md` | ∞ | 1 pass |
| `executive-ops-officer/CLAUDE.md` | ∞ | 1 pass |
| `engineering/base.md` | ∞ | no tokens |
| `operator-base.md` | ∞ | no tokens |
| `engineering/project-overview.md` | 1 pass | 1 pass |

Found while bootstrapping `bh679/mortal-me`, which worked around it locally by skipping
include tokens on any line containing `<!--`.

## Approach

Three fix options were on the table: escape the token, reword it to prose, or teach the skill
to skip tokens inside comments.

**Chose rewording to prose.** Escaping (e.g. `{{ INCLUDE:... }}`) still leaves a string that a
whitespace-tolerant regex would match; a string that isn't there cannot be matched by any
resolver, however lenient. Teaching only the skill to skip comments would leave the trap armed
for every other consumer of these templates — so that fix is included as well, but as defence
in depth rather than the primary remedy.

## Changes

- **`templates/engineering/base.md`, `templates/operator-base.md`** — provenance comment names
  the include path in prose. Includes a line stating *why* the literal token must not be
  restored: this comment is inlined into every consumer `CLAUDE.md`, so a future editor
  "fixing" the inconsistency would silently re-arm the loop.
- **`templates/README.md`** — authoring rule forbidding self-referential include tokens in any
  file that is itself inlined, plus an explicit note that README's own token examples are
  illustrative (it is never copied into a project).
- **`wiki/Token-System.md`** — same rule mirrored into the published token docs.
- **`skills/new-project/SKILL.md`** — Step 2b now defines a live token as one alone on its own
  line (skip HTML comments and code spans), and adds a repeated-path cycle guard that halts and
  reports rather than looping. Bumped `1.1.1` → `1.2.0` (new resolution rules, backwards
  compatible); `skills-versions.json` regenerated.

## Blast radius

Templates are copied once at init time and do not auto-propagate, so **this affects new
bootstraps only** — no existing consumer repo needs remediation. `mortal-me` is the only repo
that hit this; its local workaround now coincides with the documented rule rather than being a
one-off hack.

Also worth noting: the Step 8 verification check ``No literal `{{INCLUDE:` tokens remaining``
was previously wrong — the provenance comment survived resolution into the copied file, so the
check would flag correctly-resolved output. It is accurate as written now, and needed no edit.

## Test plan

- [x] Simulated the naive Step 2b resolver over all template entry points — 6/7 non-terminating
      before, 7/7 clean after (harness stashed `templates/` to compare against `HEAD`)
- [x] `.github/scripts/check-skill-versions-ci.sh` passes (`new-project` bump detected,
      `skills-versions.json` in sync)
- [x] `grep -rn '{{INCLUDE:' templates/ | grep '<!--'` returns nothing
- [x] Remaining `{{INCLUDE:...}}` occurrences confirmed live-and-acyclic or documentation-only
      (README, wiki, `apply-template` references)
- [ ] **Reviewer:** run `/new-project` end-to-end against a throwaway repo and confirm the
      generated `CLAUDE.md` contains no unresolved `{{` tokens
- [ ] **Reviewer:** confirm the reworded provenance comment reads acceptably where it lands —
      inlined near the top of every consumer `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
