### PR TITLE
feat: require a git worktree for all development, enforced by hook

### DIFF
--- a/.claude/no-worktree
+++ b/.claude/no-worktree
@@ -1,0 +1,2 @@
+This repo is the source of the worktree standard and is edited in place.
+See rules/git.md § Git Worktrees — Exemptions.

--- a/hooks/git/pre-bash.sh
+++ b/hooks/git/pre-bash.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
-# hook-version: 1.0.0
+# hook-version: 1.1.0
 # git/pre-bash.sh
-HOOK_VERSION="1.0.0"
+HOOK_VERSION="1.1.0"
 #
 # Claude Code PreToolUse hook — enforces git.md standards before Bash tool executes.
 #
 # Rules enforced:
 #   1. Block commits directly to main/master       (hard block — exit 1)
-#   2. Warn if new branch missing dev/ prefix      (soft warn — exit 0)
-#   3. Block gh pr create if branch is behind main (hard block — exit 1)
-#   4. Block gh pr merge without --squash          (hard block — exit 1)
+#   2. Block commits outside a git worktree        (hard block — exit 1)
+#   3. Warn if new branch missing dev/ prefix      (soft warn — exit 0)
+#   4. Block gh pr create if branch is behind main (hard block — exit 1)
+#   5. Block gh pr merge without --squash          (hard block — exit 1)
+#
+# Rule 2 opt-outs: a `.claude/no-worktree` marker at the repo root exempts the whole
+#       repo; CLAUDE_ALLOW_NON_WORKTREE=1 exempts a single command.
 #
 # Note: force push, reset --hard, and rm -rf are blocked via settings.json
 #       deny permissions — no hook needed for those.
@@ -35,14 +39,41 @@ if echo "$CMD" | grep -qE "^git commit"; then
     red "Direct commits to main are not allowed per git.md standards."
     dim ""
     dim "Create a feature worktree first:"
-    dim "  git worktree add ../worktrees/<feature-slug> -b dev/<feature-slug>"
+    dim "  git worktree add .claude/worktrees/<feature-slug> -b dev/<feature-slug>"
     exit 1
   fi
 fi
 
-# ── 2. Warn if new branch doesn't use dev/ prefix ──────────────────────────
+# ── 2. Block commits outside a git worktree ────────────────────────────────
+# git.md § Git Worktrees: all development happens in a worktree, never the main checkout.
+# Detection: in a linked worktree, --git-dir points at .git/worktrees/<name> while
+# --git-common-dir points at the shared .git. In a normal checkout the two are equal.
+if echo "$CMD" | grep -qE "^git commit"; then
+  GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || echo "")
+  if [ -n "$GIT_DIR" ]; then          # skip silently when not in a git repo
+    COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+    TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [ "$GIT_DIR" = "$COMMON_DIR" ] \
+       && [ "${CLAUDE_ALLOW_NON_WORKTREE:-0}" != "1" ] \
+       && [ ! -f "${TOPLEVEL}/.claude/no-worktree" ]; then
+      red "BLOCKED: You are committing from the main checkout, not a worktree."
+      red "All development happens in a git worktree per git.md standards."
+      dim ""
+      dim "Create one and move your work there:"
+      dim "  git worktree add .claude/worktrees/<feature-slug> -b dev/<feature-slug>"
+      dim "  cd .claude/worktrees/<feature-slug>"
+      dim ""
+      dim "Opt out: touch .claude/no-worktree (whole repo)"
+      dim "         CLAUDE_ALLOW_NON_WORKTREE=1 (this command only)"
+      exit 1
+    fi
+  fi
+fi
+
+# ── 3. Warn if new branch doesn't use dev/ prefix ──────────────────────────
 if echo "$CMD" | grep -qE "git (checkout|switch) -b "; then
-  BRANCH=$(echo "$CMD" | grep -oP "(?<=-b )\S+" | head -1)
+  # Portable extraction — BSD grep (macOS) has no -P, so avoid lookbehind.
+  BRANCH=$(echo "$CMD" | sed -n 's/.*-b  *\([^ ][^ ]*\).*/\1/p' | head -1)
   if [ -n "$BRANCH" ] && ! echo "$BRANCH" | grep -q "^dev/"; then
     warn "WARNING: Branch '$BRANCH' does not follow the dev/<feature-slug> naming convention."
     warn "Rename to: dev/$BRANCH"
@@ -51,7 +82,7 @@ if echo "$CMD" | grep -qE "git (checkout|switch) -b "; then
   fi
 fi
 
-# ── 3. Block PR creation if branch is behind main ────────────────────────
+# ── 4. Block PR creation if branch is behind main ────────────────────────
 if echo "$CMD" | grep -q "gh pr create"; then
   # Fetch latest main silently
   git fetch origin main --quiet 2>/dev/null || true
@@ -68,7 +99,7 @@ if echo "$CMD" | grep -q "gh pr create"; then
   fi
 fi
 
-# ── 4. Block PR merge without --squash ─────────────────────────────────────
+# ── 5. Block PR merge without --squash ─────────────────────────────────────
 if echo "$CMD" | grep -q "gh pr merge"; then
   if ! echo "$CMD" | grep -q -- "--squash"; then
     red "BLOCKED: PRs must be squash merged per git.md standards."

--- a/playbooks/gates/gate-1-plan.md
+++ b/playbooks/gates/gate-1-plan.md
@@ -1,4 +1,4 @@
-<!-- gate: gate-1-plan | version: 1.0.0 -->
+<!-- gate: gate-1-plan | version: 1.1.0 -->
 # Gate 1 — Plan Approval
 
 **Trigger:** Before writing any code.
@@ -22,10 +22,49 @@
    - Risks or dependencies
    - Deployment impact (see checklist below)
 5. Present the plan to the user via `ExitPlanMode`
+6. After approval, ensure you are in a worktree on a `dev/` branch (see below) — **before writing any code**
 
 **Gate requirement:** User clicks Approve in plan mode.
 
 **Never skip:** Even for "simple" changes. Plan mode catches assumptions early.
+
+## Post-Approval: Worktree & Branch
+
+Immediately after plan approval, before writing any code, get into a worktree on a `dev/` branch.
+Which step applies depends on how the session started — check first:
+
+```bash
+[ "$(git rev-parse --git-dir)" = "$(git rev-parse --git-common-dir)" ] \
+  && echo "NOT in a worktree — do step 1" \
+  || echo "already in a worktree — do step 2"
+```
+
+### Step 1 — Not in a worktree: create one
+
+Every change needs a worktree (`git.md` § Git Worktrees — enforced by the pre-bash hook, which
+blocks `git commit` outside one). Create it and do all work from there:
+
+```bash
+git worktree add .claude/worktrees/<feature-slug> -b dev/<feature-slug>
+cd .claude/worktrees/<feature-slug>
+```
+
+### Step 2 — Already in a worktree: rename the branch
+
+Worktree sessions auto-assign a `claude/<slug>` branch name. Rename it to `dev/<feature-slug>`:
+
+```bash
+# Derive a 3-5 word kebab-case slug from the feature name
+OLD=$(git rev-parse --abbrev-ref HEAD)          # e.g. claude/competent-joliot-87b1ca
+NEW="dev/<feature-slug>"                         # e.g. dev/ender-chest-persistence
+
+git branch -m "$OLD" "$NEW"
+git push origin "$NEW"
+git push origin --delete "$OLD"
+git branch --set-upstream-to="origin/$NEW" "$NEW"
+```
+
+This keeps all PRs, CI runs, and branch history under the standard `dev/` prefix.
 
 ## Related Playbooks
 Before creating or searching board items, read `~/.claude/playbooks/project-board.md`.

--- a/rules/git.md
+++ b/rules/git.md
@@ -1,12 +1,23 @@
-<!-- standard: git | version: 1.4.0 -->
+<!-- standard: git | version: 1.5.0 -->
 # Git Standards
 
 ## Branch Naming
 Format: `dev/<feature-slug>` — kebab-case, 3-5 words, one branch per feature/session.
 
 ## Git Worktrees
-Use worktrees for multi-repo projects (e.g. client + API on separate ports). Optional for single-repo — a normal feature branch is sufficient.
-All development happens in isolation — never directly on `main`.
+**All development happens in a git worktree — single-repo or multi-repo, feature or one-line hotfix.**
+The working checkout of `main` is never used for feature work. Create the worktree before writing any code:
+
+```bash
+git worktree add .claude/worktrees/<feature-slug> -b dev/<feature-slug>
+```
+
+All development happens in isolation — never directly on `main`. This is enforced by
+`hooks/git/pre-bash.sh`, which blocks `git commit` outside a worktree.
+
+**Exemptions:** a repo that legitimately never uses worktrees can opt out with a
+`.claude/no-worktree` marker file at its root. For a single command, set
+`CLAUDE_ALLOW_NON_WORKTREE=1`.
 
 ## Commits
 **Commit and push after every meaningful unit of work.** Never end a session with uncommitted changes.

--- a/templates/engineering/base.md
+++ b/templates/engineering/base.md
@@ -26,6 +26,7 @@ Those gate playbooks reference further playbooks as needed.
 - **Gates apply to ALL changes — bug fixes, hotfixes, one-liners, and fully-specified tasks**
 - Re-read CLAUDE.md at every gate
 - Check for existing board items before creating
+- **All work happens in a git worktree on a `dev/` branch — never the main checkout.** Create it at Gate 1, before any code
 - Clean up worktrees and ports when done
 - One feature per session
 - Commit and push after every meaningful unit of work


### PR DESCRIPTION
## Why

Worktrees were **optional for single-repo projects** (`rules/git.md:8`), and nothing in the gate flow ever created one — `gate-1-plan.md` only covered *renaming* a branch inside a worktree that already existed. Nothing detected the absence of one.

The `pre-bash.sh` hook already suggested `git worktree add`, but only in the error text for the main/master block — i.e. only once you were already on `main`.

Net effect: nothing created a worktree, and nothing noticed when there wasn't one.

## What changed

| File | Change |
|---|---|
| `rules/git.md` | 1.4.0 → 1.5.0 — worktrees mandatory single- **and** multi-repo, canonical creation command, Exemptions note |
| `playbooks/gates/gate-1-plan.md` | 1.0.0 → 1.1.0 — *Post-Approval: Rename Branch* → *Worktree & Branch*: detect first, then create (step 1) or rename (step 2). Worktree setup added as Agent Action 6 |
| `templates/engineering/base.md` | Key Rules Summary states the requirement, not just the cleanup |
| `hooks/git/pre-bash.sh` | 1.0.0 → 1.1.0 — new rule 2, plus a bug fix (below) |
| `.claude/no-worktree` | Exempts this repo — it is the source of the standard and is edited in place |

### Enforcement

Rule 2 blocks `git commit` when `git rev-parse --git-dir` equals `--git-common-dir` — true in a normal checkout, false in a linked worktree. Rule 1 (main/master) still runs first so that case keeps its more specific message.

Opt-outs: `.claude/no-worktree` marker at the repo root (whole repo), or `CLAUDE_ALLOW_NON_WORKTREE=1` (single command).

### Drive-by bug fix

Rule 3 — the "branch doesn't use `dev/` prefix" warning — used `grep -oP`. That's GNU-only; BSD grep on macOS rejects `-P`, so the rule errored out and **the warning had never fired on macOS**. Replaced with a portable `sed`.

## Test plan

Hook driven directly with its real payload against a throwaway repo — **11/11 passed**.

New rule 2:
- [x] Inside a real worktree → allow
- [x] Main checkout on a `dev/` branch → block, correct message
- [x] `CLAUDE_ALLOW_NON_WORKTREE=1` → allow
- [x] `.claude/no-worktree` marker → allow
- [x] Not a git repo → allow (skip silently)

Regressions:
- [x] Commit on `main` → block with main/master message
- [x] `checkout -b foo` → warns, exit 0 *(newly working)*
- [x] `checkout -b dev/good-slug` → silent
- [x] `gh pr merge 7` → block; with `--squash` → allow
- [x] Unrelated command → allow
- [x] `bash -n` clean; `check-hooks.sh` reports 1.1.0 up-to-date

## Rollout note

The other ~14 repos in `consumers.json` pick this up on their next `apply-template` / hook install — deliberately untouched here. `ideas` and `weekly-blog` may want a `.claude/no-worktree` marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)